### PR TITLE
Inital changes to support PointValues with Summary information for timeseries use case

### DIFF
--- a/lucene/backward-codecs/src/java/module-info.java
+++ b/lucene/backward-codecs/src/java/module-info.java
@@ -51,5 +51,6 @@ module org.apache.lucene.backward_codecs {
       org.apache.lucene.backward_codecs.lucene87.Lucene87Codec,
       org.apache.lucene.backward_codecs.lucene90.Lucene90Codec,
       org.apache.lucene.backward_codecs.lucene91.Lucene91Codec,
-      org.apache.lucene.backward_codecs.lucene92.Lucene92Codec;
+      org.apache.lucene.backward_codecs.lucene92.Lucene92Codec,
+      org.apache.lucene.backward_codecs.lucene93Ext.Lucene93ExtCodec;
 }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene93Ext/Lucene93ExtCodec.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene93Ext/Lucene93ExtCodec.java
@@ -1,0 +1,51 @@
+package org.apache.lucene.backward_codecs.lucene93Ext;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.PointsFormat;
+import org.apache.lucene.codecs.PointsReader;
+import org.apache.lucene.codecs.PointsWriter;
+import org.apache.lucene.codecs.lucene93.Lucene93Codec;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.util.bkd.BKDConfig;
+import org.apache.lucene.util.bkd.BKDWriter;
+
+import java.io.IOException;
+
+public class Lucene93ExtCodec extends FilterCodec {
+
+    public static final String SUMMARY_INDEX_EXTENSION = "kdsi";
+
+    public static final String SUMMARY_DATA_EXTENSION = "kdsd";
+    public static final String SUMMARY_DATA_CODEC_NAME = "Lucene93PointsFormatSummaryData";
+    public static final String SUMMARY_INDEX_CODEC_NAME = "Lucene93PointsFormatSummaryIndex";
+
+    final int maxPointsInLeafNode;
+    final double maxMBSortHeap;
+
+    public Lucene93ExtCodec() {
+        this(new Lucene93Codec(), BKDConfig.DEFAULT_MAX_POINTS_IN_LEAF_NODE,
+                BKDWriter.DEFAULT_MAX_MB_SORT_IN_HEAP);
+    }
+    public Lucene93ExtCodec(Codec defaultCodec, int maxPointsInLeafNode, double maxMBSortHeap) {
+        super("Lucene93ExtCodec", defaultCodec);
+        this.maxPointsInLeafNode = maxPointsInLeafNode;
+        this.maxMBSortHeap = maxMBSortHeap;
+    }
+
+    @Override
+    public PointsFormat pointsFormat() {
+        return new PointsFormat() {
+            @Override
+            public PointsWriter fieldsWriter(SegmentWriteState writeState) throws IOException {
+                return new Lucene93ExtPointsWriter(writeState, maxPointsInLeafNode,  maxMBSortHeap);
+            }
+
+            @Override
+            public PointsReader fieldsReader(SegmentReadState readState) throws IOException {
+                return new Lucene93ExtPointsReader(readState);
+            }
+        };
+    }
+}

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene93Ext/Lucene93ExtPointsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene93Ext/Lucene93ExtPointsReader.java
@@ -1,0 +1,143 @@
+package org.apache.lucene.backward_codecs.lucene93Ext;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.lucene90.Lucene90PointsFormat;
+import org.apache.lucene.codecs.lucene90.Lucene90PointsReader;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.bkd.BKDReader;
+import org.apache.lucene.util.bkd.BKDWithSummaryReader;
+
+import java.io.IOException;
+
+public class Lucene93ExtPointsReader extends Lucene90PointsReader {
+    /**
+     * Sole constructor
+     *
+     * @param readState
+     */
+    IndexInput summaryIndexIn, summaryDataIn;
+    long summaryIndexLength = -1, summaryDataLength = -1;
+    public Lucene93ExtPointsReader(SegmentReadState readState) throws IOException {
+        super(readState);
+    }
+
+    @Override
+    public void init(SegmentReadState readState) throws IOException {
+        summaryIndexIn = getSummaryIndexIn(readState);
+        summaryDataIn = getSummaryDataIn(readState);
+    }
+    private IndexInput getSummaryIndexIn(SegmentReadState readState) throws IOException {
+        boolean success = false;
+        IndexInput summaryIndexIn = null;
+        for (FieldInfo fieldInfo : readState.fieldInfos) {
+            if (fieldInfo.hasPointsSummary()) {
+                try {
+                    String summaryIndexName =
+                            IndexFileNames.segmentFileName(
+                                    readState.segmentInfo.name,
+                                    readState.segmentSuffix,
+                                    Lucene93ExtCodec.SUMMARY_INDEX_EXTENSION);
+                    summaryIndexIn = readState.directory.openInput(summaryIndexName, readState.context);
+                    CodecUtil.checkIndexHeader(
+                            summaryIndexIn,
+                            Lucene93ExtCodec.SUMMARY_INDEX_CODEC_NAME,
+                            Lucene90PointsFormat.VERSION_START,
+                            Lucene90PointsFormat.VERSION_CURRENT,
+                            readState.segmentInfo.getId(),
+                            readState.segmentSuffix);
+                    CodecUtil.retrieveChecksum(summaryIndexIn);
+                    success = true;
+                } finally {
+                    if (success == false) {
+                        IOUtils.closeWhileHandlingException(this);
+                    }
+                }
+                break;
+            }
+        }
+        return summaryIndexIn;
+    }
+
+    private IndexInput getSummaryDataIn(SegmentReadState readState) throws IOException {
+        boolean success = false;
+        IndexInput summaryDataIn = null;
+        for (FieldInfo fieldInfo : readState.fieldInfos) {
+            if (fieldInfo.hasPointsSummary()) {
+                try {
+                    String summaryDataName =
+                            IndexFileNames.segmentFileName(
+                                    readState.segmentInfo.name,
+                                    readState.segmentSuffix,
+                                    Lucene93ExtCodec.SUMMARY_DATA_EXTENSION);
+                    summaryDataIn = readState.directory.openInput(summaryDataName, readState.context);
+                    CodecUtil.checkIndexHeader(
+                            summaryDataIn,
+                            Lucene93ExtCodec.SUMMARY_DATA_CODEC_NAME,
+                            Lucene90PointsFormat.VERSION_START,
+                            Lucene90PointsFormat.VERSION_CURRENT,
+                            readState.segmentInfo.getId(),
+                            readState.segmentSuffix);
+                    CodecUtil.retrieveChecksum(summaryDataIn);
+                    success = true;
+                } finally {
+                    if (success == false) {
+                        IOUtils.closeWhileHandlingException(this);
+                    }
+                }
+                break;
+            }
+        }
+        return summaryDataIn;
+    }
+
+    @Override
+    public BKDReader getBKDReader(SegmentReadState readState, int fieldNumber, IndexInput metaIn, IndexInput indexIn, IndexInput dataIn)
+            throws IOException {
+        if (readState.fieldInfos.fieldInfo(fieldNumber).hasPointsSummary()) {
+            return new BKDWithSummaryReader(metaIn, indexIn, dataIn, summaryIndexIn, summaryDataIn);
+        } else {
+            return super.getBKDReader(readState, fieldNumber, metaIn, indexIn, dataIn);
+        }
+    }
+
+    @Override
+    public void readAdditionalMetadata(IndexInput metaIn) throws IOException {
+        super.readAdditionalMetadata(metaIn);
+        if (summaryIndexIn != null) {
+            summaryIndexLength = metaIn.readLong();
+            summaryDataLength = metaIn.readLong();
+        }
+    }
+
+    @Override
+    public void retrieveAdditionalChecksum() throws IOException {
+        super.retrieveAdditionalChecksum();
+        if (summaryIndexIn != null) {
+            CodecUtil.retrieveChecksum(summaryIndexIn, summaryIndexLength);
+        }
+        if (summaryDataIn != null) {
+            CodecUtil.retrieveChecksum(summaryDataIn, summaryDataLength);
+        }
+    }
+
+    @Override
+    public void checkIntegrity() throws IOException {
+        super.checkIntegrity();
+        if (summaryIndexIn != null) {
+            CodecUtil.checksumEntireFile(summaryIndexIn);
+        }
+        if (summaryDataIn != null) {
+            CodecUtil.checksumEntireFile(summaryDataIn);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(summaryIndexIn, summaryDataIn);
+        super.close();
+    }
+}

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene93Ext/Lucene93ExtPointsWriter.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene93Ext/Lucene93ExtPointsWriter.java
@@ -95,7 +95,11 @@ public class Lucene93ExtPointsWriter extends Lucene90PointsWriter {
     @Override
     public Runnable writerFinish(BKDWriter writer, IndexOutput metaOut, IndexOutput indexOut, IndexOutput dataOut)
             throws IOException {
-        throw new UnsupportedOperationException("Merge on BKDTrees is not yet supported yet");
+        if (writer instanceof BKDSummaryWriter) {
+            throw new UnsupportedOperationException("Merge on BKDTrees is not yet supported yet");
+        } else {
+            return super.writerFinish(writer, metaOut, indexOut, dataOut);
+        }
     }
 
     @Override

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene93Ext/Lucene93ExtPointsWriter.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene93Ext/Lucene93ExtPointsWriter.java
@@ -1,0 +1,132 @@
+package org.apache.lucene.backward_codecs.lucene93Ext;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.MutableSummaryPointTree;
+import org.apache.lucene.codecs.lucene90.Lucene90PointsFormat;
+import org.apache.lucene.codecs.lucene90.Lucene90PointsWriter;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.bkd.BKDConfig;
+import org.apache.lucene.util.bkd.BKDSummaryWriter;
+import org.apache.lucene.util.bkd.BKDWriter;
+
+import java.io.IOException;
+
+public class Lucene93ExtPointsWriter extends Lucene90PointsWriter {
+    protected IndexOutput summaryIndex = null, summaryData = null;
+    SegmentWriteState writeState;
+
+    public Lucene93ExtPointsWriter(SegmentWriteState writeState, int maxPointsInLeafNode, double maxMBSortInHeap) throws IOException {
+        super(writeState, maxPointsInLeafNode, maxMBSortInHeap);
+        this.writeState = writeState;
+    }
+
+    public Lucene93ExtPointsWriter(SegmentWriteState writeState) throws IOException {
+        super(writeState);
+    }
+
+    @Override
+    public BKDWriter getBKDWriter(SegmentWriteState writeState, PointValues.PointTree values, BKDConfig config, FieldInfo fieldInfo) {
+        if(values instanceof MutableSummaryPointTree && fieldInfo.hasPointsSummary()) {
+            return new BKDSummaryWriter(
+                    writeState.segmentInfo.maxDoc(),
+                    writeState.directory,
+                    writeState.segmentInfo.name,
+                    config,
+                    maxMBSortInHeap,
+                    values.size());
+        } else {
+            return super.getBKDWriter(writeState, values, config, fieldInfo);
+        }
+    }
+
+    @Override
+    public Runnable writeField(IndexOutput metaOut,
+                               IndexOutput indexOut,
+                               IndexOutput dataOut,
+                               FieldInfo fieldInfo,
+                               PointValues.PointTree pointTree,
+                               BKDWriter writer) throws IOException {
+        if(pointTree instanceof MutableSummaryPointTree && fieldInfo.hasPointsSummary()) {
+            initSummaryFiles();
+            return ((BKDSummaryWriter) writer).writeField(metaOut, indexOut, dataOut, summaryIndex, summaryData,
+                    fieldInfo.getName(), (MutableSummaryPointTree) pointTree, fieldInfo.getMergeFunction());
+        } else {
+            return super.writeField(metaOut, indexOut, dataOut, fieldInfo, pointTree, writer);
+        }
+    }
+
+    private void initSummaryFiles() throws IOException {
+        if (summaryIndex == null) {
+            String summaryIndexFileName =
+                    IndexFileNames.segmentFileName(
+                            writeState.segmentInfo.name,
+                            writeState.segmentSuffix,
+                            Lucene93ExtCodec.SUMMARY_INDEX_EXTENSION);
+            summaryIndex = writeState.directory.createOutput(summaryIndexFileName, writeState.context);
+            CodecUtil.writeIndexHeader(
+                    summaryIndex,
+                    Lucene93ExtCodec.SUMMARY_INDEX_CODEC_NAME,
+                    Lucene90PointsFormat.VERSION_CURRENT,
+                    writeState.segmentInfo.getId(),
+                    writeState.segmentSuffix);
+        }
+
+        if (summaryData == null) {
+            String summaryDataFileName =
+                    IndexFileNames.segmentFileName(
+                            writeState.segmentInfo.name,
+                            writeState.segmentSuffix,
+                            Lucene93ExtCodec.SUMMARY_DATA_EXTENSION);
+            summaryData = writeState.directory.createOutput(summaryDataFileName, writeState.context);
+            CodecUtil.writeIndexHeader(
+                    summaryData,
+                    Lucene93ExtCodec.SUMMARY_DATA_CODEC_NAME,
+                    Lucene90PointsFormat.VERSION_CURRENT,
+                    writeState.segmentInfo.getId(),
+                    writeState.segmentSuffix);
+        }
+    }
+
+    @Override
+    public Runnable writerFinish(BKDWriter writer, IndexOutput metaOut, IndexOutput indexOut, IndexOutput dataOut)
+            throws IOException {
+        throw new UnsupportedOperationException("Merge on BKDTrees is not yet supported yet");
+    }
+
+    @Override
+    public void finish() throws IOException {
+        if (summaryIndex != null) {
+            CodecUtil.writeFooter(summaryIndex);
+        }
+        if (summaryData != null) {
+            CodecUtil.writeFooter(summaryData);
+        }
+        super.finish();
+    }
+
+    public void writeAdditionalMetadata(IndexOutput metaOut) throws IOException {
+        super.writeAdditionalMetadata(metaOut);
+        if (summaryIndex != null) {
+            metaOut.writeLong(summaryIndex.getFilePointer());
+        }
+        if (summaryData != null) {
+            metaOut.writeLong(summaryData.getFilePointer());
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        if (summaryIndex != null) {
+            IOUtils.close(summaryIndex);
+        }
+        if (summaryData != null) {
+            IOUtils.close(summaryData);
+        }
+    }
+}

--- a/lucene/backward-codecs/src/resources/META-INF/services/org.apache.lucene.codecs.Codec
+++ b/lucene/backward-codecs/src/resources/META-INF/services/org.apache.lucene.codecs.Codec
@@ -20,3 +20,4 @@ org.apache.lucene.backward_codecs.lucene87.Lucene87Codec
 org.apache.lucene.backward_codecs.lucene90.Lucene90Codec
 org.apache.lucene.backward_codecs.lucene91.Lucene91Codec
 org.apache.lucene.backward_codecs.lucene92.Lucene92Codec
+org.apache.lucene.backward_codecs.lucene93Ext.Lucene93ExtCodec

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene93Ext/TestLucene93ExtPointFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene93Ext/TestLucene93ExtPointFormat.java
@@ -63,7 +63,7 @@ public class TestLucene93ExtPointFormat extends BasePointsFormatTestCase {
         iwc.setMergePolicy(mergePolicy);
         IndexWriter w = new IndexWriter(dir, iwc);
 
-        final int numDocs = 10000000;
+        final int numDocs = 100000;
         int low = random().nextInt(numDocs/100);
         int high = random().nextInt(low, numDocs - 1);
         int exp = 0;
@@ -115,8 +115,8 @@ public class TestLucene93ExtPointFormat extends BasePointsFormatTestCase {
             }
             assertEquals(exp, actualCount);
 
-            System.out.println("Matching docs count:" + actualCount + " | Segments:" + segments + " | DiskAccess: "
-                    + diskAccess);
+            // System.out.println("Matching docs count:" + actualCount + " | Segments:" + segments + " | DiskAccess: "
+            //        + diskAccess);
         }
         r.close();
         finish = Instant.now();
@@ -139,7 +139,7 @@ public class TestLucene93ExtPointFormat extends BasePointsFormatTestCase {
         MergePolicy mergePolicy = NoMergePolicy.INSTANCE;
         iwc.setMergePolicy(mergePolicy);
         IndexWriter w = new IndexWriter(dir, iwc);
-        final int numDocs = 10000000;
+        final int numDocs = 100000;
         int low = random().nextInt(numDocs/100);
         int high = random().nextInt(low, numDocs - 1);
         int exp = 0;
@@ -205,8 +205,8 @@ public class TestLucene93ExtPointFormat extends BasePointsFormatTestCase {
             });
             assertEquals(exp, actualRes[0]);
 
-            System.out.println("Matching docs count:" + match[0] + " | Segments:" + segments[0] + " | DiskAccess: "
-                    + match[0]);
+            // System.out.println("Matching docs count:" + match[0] + " | Segments:" + segments[0] + " | DiskAccess: "
+            //         + match[0]);
 
         }
         reader.close();

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene93Ext/TestLucene93ExtPointFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene93Ext/TestLucene93ExtPointFormat.java
@@ -1,0 +1,220 @@
+package org.apache.lucene.backward_codecs.lucene93Ext;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.lucene93.Lucene93Codec;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.TSIntPoint;
+import org.apache.lucene.document.TSPointQuery;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.BasePointsFormatTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.NumericUtils;
+import org.apache.lucene.util.bkd.BKDSummaryWriter;
+import org.apache.lucene.util.bkd.BKDWithSummaryReader;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Random;
+
+;import static org.apache.lucene.search.ScoreMode.COMPLETE_NO_SCORES;
+
+public class TestLucene93ExtPointFormat extends BasePointsFormatTestCase {
+
+    @Override
+    protected Codec getCodec() {
+        int maxPointsInLeafNode = TestUtil.nextInt(random(), 50, 500);
+        double maxMBSortInHeap = 3.0 + (3 * random().nextDouble());
+        return new Lucene93ExtCodec(new Lucene93Codec(), maxPointsInLeafNode, maxMBSortInHeap);
+    }
+
+    public void testTSPointCount() throws IOException {
+        Instant start = Instant.now();
+
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = new IndexWriterConfig();
+        // Avoid mockRandomMP since it may cause non-optimal merges that make the
+        // number of points per leaf hard to predict
+        // while (iwc.getMergePolicy() instanceof MockRandomMergePolicy) {
+        //    iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        // }
+        MergePolicy mergePolicy = NoMergePolicy.INSTANCE;
+        iwc.setMergePolicy(mergePolicy);
+        IndexWriter w = new IndexWriter(dir, iwc);
+
+        final int numDocs = 10000000;
+        int low = random().nextInt(numDocs/100);
+        int high = random().nextInt(low, numDocs - 1);
+        int exp = 0;
+        for (int i = 0; i < numDocs; ++i) {
+            Document doc = new Document();
+            int measurement = random().nextInt(3);
+            doc.add(new TSIntPoint("tsid1", "tsid1_cpu", i, measurement));
+            if (i >= low && i <= high) {
+                exp += measurement;
+            }
+            w.addDocument(doc);
+        }
+
+
+        w.flush();
+        final IndexReader r = DirectoryReader.open(w);
+        if (w.isOpen())
+            w.close();
+        Instant finish = Instant.now();
+        long timeElapsed = Duration.between(start, finish).toMillis();
+        start = Instant.now();
+        System.out.println("Indexing took: " + timeElapsed);
+        // w.forceMerge(1);
+        int tt = 100;
+        while(tt-->0) {
+
+            byte[] lowerPoint = new byte[8];
+            byte[] upperPoint = new byte[8];
+
+            NumericUtils.longToSortableBytes(low, lowerPoint, 0);
+            NumericUtils.longToSortableBytes(high, upperPoint, 0);
+            int actualCount = 0;
+            int segments = 0, matches = 0;
+            int diskAccess = 0;
+            for (LeafReaderContext readerContext : r.leaves()) {
+                final LeafReader lr = readerContext.reader();
+                PointValues points = lr.getPointValues("tsid1");
+                FieldInfo fieldInfo = lr.getFieldInfos().fieldInfo("tsid1");
+                BKDSummaryWriter.SummaryMergeFunction<?> mergeFunction = fieldInfo.getMergeFunction();
+
+                TSPointQuery tsPointQuery = new TSPointQuery("tsid1", lowerPoint, upperPoint);
+                byte[] res = tsPointQuery.getSummary((BKDWithSummaryReader.BKDSummaryTree) points.getPointTree(), mergeFunction);
+                if (res != null) {
+                    actualCount += (Integer) mergeFunction.unpackBytes(res);
+                }
+                // lr.close();
+                segments++;
+                diskAccess += tsPointQuery.diskAccess[0];
+            }
+            assertEquals(exp, actualCount);
+
+            System.out.println("Matching docs count:" + actualCount + " | Segments:" + segments + " | DiskAccess: "
+                    + diskAccess);
+        }
+        r.close();
+        finish = Instant.now();
+        timeElapsed = Duration.between(start, finish).toMillis();
+        System.out.println("Search took: " + timeElapsed);
+        //r.close();
+        dir.close();
+    }
+
+    public void testPointCount() throws IOException {
+        Instant start = Instant.now();
+
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = new IndexWriterConfig();
+        // Avoid mockRandomMP since it may cause non-optimal merges that make the
+        // number of points per leaf hard to predict
+        // while (iwc.getMergePolicy() instanceof MockRandomMergePolicy) {
+        //    iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        // }
+        MergePolicy mergePolicy = NoMergePolicy.INSTANCE;
+        iwc.setMergePolicy(mergePolicy);
+        IndexWriter w = new IndexWriter(dir, iwc);
+        final int numDocs = 10000000;
+        int low = random().nextInt(numDocs/100);
+        int high = random().nextInt(low, numDocs - 1);
+        int exp = 0;
+        for (int i = 0; i < numDocs; ++i) {
+            Document doc = new Document();
+            int measurement = random().nextInt(3);
+            doc.add(new TextField("tsid", "tsid1", Field.Store.NO));
+            // doc.add(new LongPoint("timestamp", i));
+            doc.add(new SortedNumericDocValuesField("timestamp", i));
+            doc.add(new NumericDocValuesField("measurement", measurement));
+            if (i >= low && i <= high) {
+                exp += measurement;
+            }
+            w.addDocument(doc);
+        }
+        w.flush();
+        final IndexReader reader = DirectoryReader.open(w);
+        final IndexSearcher searcher = newSearcher(reader, false);
+        if (w.isOpen())
+            w.close();
+        int tt = 100;
+        Instant finish = Instant.now();
+        long timeElapsed = Duration.between(start, finish).toMillis();
+        start = Instant.now();
+        System.out.println("Indexing took: " + timeElapsed);
+        while(tt-->0) {
+            byte[] lowerPoint = new byte[8];
+            byte[] upperPoint = new byte[8];
+
+            NumericUtils.longToSortableBytes(low, lowerPoint, 0);
+            NumericUtils.longToSortableBytes(high, upperPoint, 0);
+            // final Query q = LongPoint.newRangeQuery("timestamp", low, high);
+            final Query q = SortedNumericDocValuesField.newSlowRangeQuery("timestamp", low, high);
+
+            final long[] actualRes = {0};
+            final int[] match = {0};
+            final int[] segments = {0};
+            searcher.search(q, new Collector() {
+                @Override
+                public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+                    final NumericDocValues values = context.reader().getNumericDocValues("measurement");
+                    segments[0]++;
+                    return new LeafCollector() {
+                        @Override
+                        public void setScorer(Scorable scorer) throws IOException {
+
+                        }
+
+                        @Override
+                        public void collect(int doc) throws IOException {
+                            match[0]++;
+                            values.advance(doc);
+
+                            actualRes[0] += values.longValue();
+                        }
+                    };
+                }
+
+                @Override
+                public ScoreMode scoreMode() {
+                    return COMPLETE_NO_SCORES;
+                }
+            });
+            assertEquals(exp, actualRes[0]);
+
+            System.out.println("Matching docs count:" + match[0] + " | Segments:" + segments[0] + " | DiskAccess: "
+                    + match[0]);
+
+        }
+        reader.close();
+        finish = Instant.now();
+        timeElapsed = Duration.between(start, finish).toMillis();
+        System.out.println("Search took: " + timeElapsed);
+
+        dir.close();
+
+    }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/MutableSummaryPointTree.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/MutableSummaryPointTree.java
@@ -1,0 +1,5 @@
+package org.apache.lucene.codecs;
+
+public abstract class MutableSummaryPointTree extends MutablePointTree {
+
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PointsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PointsFormat.java
@@ -58,8 +58,8 @@ public final class Lucene90PointsFormat extends PointsFormat {
   /** Filename extension for the meta per field */
   public static final String META_EXTENSION = "kdm";
 
-  static final int VERSION_START = 0;
-  static final int VERSION_CURRENT = VERSION_START;
+  public static final int VERSION_START = 0;
+  public static final int VERSION_CURRENT = VERSION_START;
 
   /** Sole constructor */
   public Lucene90PointsFormat() {}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PointsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PointsReader.java
@@ -40,7 +40,7 @@ public class Lucene90PointsReader extends PointsReader {
   /** Sole constructor */
   public Lucene90PointsReader(SegmentReadState readState) throws IOException {
     this.readState = readState;
-
+    init(readState);
     String metaFileName =
         IndexFileNames.segmentFileName(
             readState.segmentInfo.name,
@@ -99,11 +99,12 @@ public class Lucene90PointsReader extends PointsReader {
             } else if (fieldNumber < 0) {
               throw new CorruptIndexException("Illegal field number: " + fieldNumber, metaIn);
             }
-            PointValues reader = new BKDReader(metaIn, indexIn, dataIn);
+            PointValues reader = getBKDReader(readState, fieldNumber, metaIn, indexIn, dataIn);
             readers.put(fieldNumber, reader);
           }
           indexLength = metaIn.readLong();
           dataLength = metaIn.readLong();
+          readAdditionalMetadata(metaIn);
         } catch (Throwable t) {
           priorE = t;
         } finally {
@@ -114,12 +115,29 @@ public class Lucene90PointsReader extends PointsReader {
       // know that indexLength and dataLength are very likely correct.
       CodecUtil.retrieveChecksum(indexIn, indexLength);
       CodecUtil.retrieveChecksum(dataIn, dataLength);
+      retrieveAdditionalChecksum();
       success = true;
     } finally {
       if (success == false) {
         IOUtils.closeWhileHandlingException(this);
       }
     }
+  }
+
+  public void init(SegmentReadState readState) throws IOException {
+
+  }
+
+  public BKDReader getBKDReader(SegmentReadState readState, int fieldNo, IndexInput metaIn, IndexInput indexIn, IndexInput dataIn) throws IOException {
+    return new BKDReader(metaIn, indexIn, dataIn);
+  }
+
+  public void readAdditionalMetadata(IndexInput metaIn) throws IOException {
+
+  }
+
+  public void retrieveAdditionalChecksum() throws IOException {
+
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/document/LongPoint.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LongPoint.java
@@ -47,7 +47,7 @@ import org.apache.lucene.util.NumericUtils;
  *
  * @see PointValues
  */
-public final class LongPoint extends Field {
+public class LongPoint extends Field {
   private static FieldType getType(int numDims) {
     FieldType type = new FieldType();
     type.setDimensions(numDims, Long.BYTES);
@@ -128,6 +128,9 @@ public final class LongPoint extends Field {
     super(name, pack(point), getType(point.length));
   }
 
+  public LongPoint(String name, FieldType type, long... point) {
+    super(name, pack(point), type);
+  }
   @Override
   public String toString() {
     StringBuilder result = new StringBuilder();

--- a/lucene/core/src/java/org/apache/lucene/document/TSIntPoint.java
+++ b/lucene/core/src/java/org/apache/lucene/document/TSIntPoint.java
@@ -1,0 +1,71 @@
+package org.apache.lucene.document;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
+import org.apache.lucene.util.bkd.BKDSummaryWriter;
+
+public class TSIntPoint extends LongPoint {
+
+    String timeSeries;
+    int measurement;
+    long timestamp;
+
+    public TSIntPoint(String name, String timeSeries, long timestamp, int measurement) {
+        super(name, getType(1, true), timestamp);
+        this.timeSeries = timeSeries;
+        this.measurement = measurement;
+    }
+    static FieldType getType(int numDims, boolean summary) {
+        assert numDims == 1;
+        FieldType type = new FieldType();
+        type.setDimensions(numDims, Long.BYTES);
+        if (summary) {
+            type.putAttribute("summary", "true");
+        }
+        type.freeze();
+        return type;
+    }
+    public String getTimSeries() {
+        return timeSeries;
+    }
+
+    public int getMeasurement() {
+        return measurement;
+    }
+
+    public BytesRef getPackedMetrics() {
+        byte [] b = new byte[Integer.BYTES];
+        NumericUtils.intToSortableBytes(measurement, b, 0);
+        return new BytesRef(b);
+    }
+
+    public long getTimeStamp() {
+        return timestamp;
+    }
+
+    public BKDSummaryWriter.SummaryMergeFunction<?> getMergeFunction() {
+        return new BKDSummaryWriter.SummaryMergeFunction<Integer>() {
+
+            @Override
+            public int getSummarySize() {
+                return Integer.BYTES;
+            }
+
+            @Override
+            public void merge(byte[] a, byte[] b, byte[] c) {
+                packBytes(unpackBytes(a) + unpackBytes(b), c);
+            }
+
+            @Override
+            public Integer unpackBytes(byte[] val) {
+                return NumericUtils.sortableBytesToInt(val, 0);
+            }
+
+            @Override
+            public void packBytes(Integer val, byte[] res) {
+                NumericUtils.intToSortableBytes(val, res, 0);
+            }
+        };
+    }
+
+}

--- a/lucene/core/src/java/org/apache/lucene/document/TSPointQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/TSPointQuery.java
@@ -1,0 +1,94 @@
+package org.apache.lucene.document;
+
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.search.*;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.bkd.BKDSummaryWriter;
+import org.apache.lucene.util.bkd.BKDWithSummaryReader;
+
+import java.io.IOException;
+
+
+public class TSPointQuery extends PointRangeQuery {
+
+    public int[] diskAccess = {0};
+    /**
+     * Expert: create a multidimensional range query for point values.
+     *
+     * @param tsid      field name. must not be {@code null}.
+     * @param lowerPoint lower portion of the range (inclusive).
+     * @param upperPoint upper portion of the range (inclusive).
+     * @throws IllegalArgumentException if {@code field} is null, or if {@code lowerValue.length !=
+     *                                  upperValue.length}
+     */
+    public TSPointQuery(String tsid, byte[] lowerPoint, byte[] upperPoint) {
+        super(tsid, lowerPoint, upperPoint, 1);
+    }
+
+    @Override
+    protected String toString(int dimension, byte[] value) {
+        return null;
+    }
+
+    public byte[] getSummary(BKDWithSummaryReader.BKDSummaryTree pointTree,
+                             BKDSummaryWriter.SummaryMergeFunction<?> mergeFunction) throws IOException {
+        final byte[][] summary = {null};
+        pointTree.visitSummary(new PointValues.IntersectVisitor() {
+            @Override
+            public void visit(int docID) throws IOException {
+
+            }
+
+            @Override
+            public void visit(int docID, byte[] packedValue) throws IOException {
+                // TODO - it will be when leaf node is reached crossing the query, we need to fetch the leaf node block
+                // to read the packed value and decide whether to include point or not, read value of metric and
+                // aggregate
+            }
+
+            @Override
+            public void visit(int docID, byte[] packedValue, byte[] packedSummary) throws IOException {
+                if (compare(packedValue, packedValue) == PointValues.Relation.CELL_INSIDE_QUERY) {
+                    diskAccess[0]++;
+                    if (summary[0] == null) {
+                        summary[0] = new byte[mergeFunction.getSummarySize()];
+                        System.arraycopy(packedSummary, 0, summary[0], 0, mergeFunction.getSummarySize());
+                    } else {
+                        mergeFunction.merge(summary[0], packedSummary, summary[0]);
+                    }
+                }
+            }
+
+            @Override
+            public PointValues.Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+                boolean crosses;
+                ArrayUtil.ByteArrayComparator comparator = ArrayUtil.getUnsignedComparator(minPackedValue.length);
+
+                if (comparator.compare(minPackedValue, 0, upperPoint, 0) > 0
+                        || comparator.compare(maxPackedValue, 0, lowerPoint, 0) < 0) {
+                    return PointValues.Relation.CELL_OUTSIDE_QUERY;
+                }
+
+                crosses = comparator.compare(minPackedValue, 0, lowerPoint, 0) < 0
+                        || comparator.compare(maxPackedValue, 0, upperPoint, 0) > 0;
+
+                if (crosses) {
+                    return PointValues.Relation.CELL_CROSSES_QUERY;
+                } else {
+                    return PointValues.Relation.CELL_INSIDE_QUERY;
+                }
+            }
+
+            @Override
+            public void visit(byte[] packedSummary, int firstDocID, int lastDocID) throws IOException {
+                diskAccess[0]++;
+                if (summary[0] == null) {
+                    summary[0] = new byte[mergeFunction.getSummarySize()];
+                    System.arraycopy(packedSummary, 0, summary[0], 0, mergeFunction.getSummarySize());
+                } else {
+                    mergeFunction.merge(summary[0], packedSummary, summary[0]);
+                }            }
+        }, 0);
+        return summary[0];
+    }
+}

--- a/lucene/core/src/java/org/apache/lucene/index/PointValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PointValues.java
@@ -317,6 +317,24 @@ public abstract class PointValues {
       }
     }
 
+    default void visit(int docID, byte[] packedValue, byte[] packedSummary) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+    /**
+     * Called for any node fully contained by the query. The caller can blindly accept it. Only called
+     * if packedSummary is supported by the tree. If visit doesn't throw UnsupportedOperationException, it is
+     * assumed that docIDs, in leaf cells under current node, doesn't need to be iterated and
+     * just summary data is of interest. Also, not all tree will support this operation,
+     * so this will never be called for trees which doesn't support/contain summary data.
+     * If the search goes down all the way to leaf cell Point, then visit(docID) will be called too!
+     * @param packedSummary aggregated summary of all the leaf cells of subtree under this node
+     * @param firstDocID the first docID present in the leaf cells under this subtree
+     * @param lastDocID the last docID present in the leaf cells under this subtree
+     * @throws IOException
+     */
+    default void visit(byte[] packedSummary, int firstDocID, int lastDocID) throws IOException {
+      throw new UnsupportedOperationException();
+    }
     /**
      * Called for non-leaf cells to test how the cell relates to the query, to determine how to
      * further recurse down the tree.

--- a/lucene/core/src/java/org/apache/lucene/index/PointValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PointValuesWriter.java
@@ -28,15 +28,15 @@ import org.apache.lucene.util.PagedBytes;
 
 /** Buffers up pending byte[][] value(s) per doc, then flushes when segment flushes. */
 class PointValuesWriter {
-  private final FieldInfo fieldInfo;
-  private final PagedBytes bytes;
+  protected final FieldInfo fieldInfo;
+  protected final PagedBytes bytes;
   private final DataOutput bytesOut;
-  private final Counter iwBytesUsed;
-  private int[] docIDs;
-  private int numPoints;
+  protected final Counter iwBytesUsed;
+  protected int[] docIDs;
+  protected int numPoints;
   private int numDocs;
   private int lastDocID = -1;
-  private final int packedBytesLength;
+  protected final int packedBytesLength;
 
   PointValuesWriter(Counter bytesUsed, FieldInfo fieldInfo) {
     this.fieldInfo = fieldInfo;

--- a/lucene/core/src/java/org/apache/lucene/index/TSPointValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TSPointValuesWriter.java
@@ -1,0 +1,188 @@
+package org.apache.lucene.index;
+
+import org.apache.lucene.codecs.MutablePointTree;
+import org.apache.lucene.codecs.MutableSummaryPointTree;
+import org.apache.lucene.codecs.PointsReader;
+import org.apache.lucene.codecs.PointsWriter;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.Counter;
+import org.apache.lucene.util.PagedBytes;
+import org.apache.lucene.util.bkd.BKDSummaryWriter;
+
+import java.io.IOException;
+
+public class TSPointValuesWriter extends PointValuesWriter {
+
+    private final PagedBytes summaryBytes;
+    private final DataOutput summaryBytesOut;
+
+    private final int packedSummaryLength;
+
+    private final BKDSummaryWriter.SummaryMergeFunction<?> mergeFunction;
+    public TSPointValuesWriter(Counter bytesUsed, FieldInfo fieldInfo) {
+        super(bytesUsed, fieldInfo);
+        this.summaryBytes = new PagedBytes(12);
+        this.summaryBytesOut = summaryBytes.getDataOutput();
+        mergeFunction = fieldInfo.getMergeFunction();
+        packedSummaryLength = mergeFunction.getSummarySize();
+    }
+
+    public void addPackedValue(int docID, BytesRef timestamp, BytesRef summaryData) throws IOException {
+        addPackedValue(docID, timestamp);
+        final long bytesRamBytesUsedBefore = summaryBytes.ramBytesUsed();
+        summaryBytesOut.writeBytes(summaryData.bytes, summaryData.offset, summaryData.length);
+        iwBytesUsed.addAndGet(summaryBytes.ramBytesUsed() - bytesRamBytesUsedBefore);
+    }
+
+    @Override
+    public void flush(SegmentWriteState state, Sorter.DocMap sortMap, PointsWriter writer)
+            throws IOException {
+        final PagedBytes.Reader bytesReader = bytes.freeze(false);
+        final PagedBytes.Reader summaryBytesReader = summaryBytes.freeze(false);
+
+        MutablePointTree points =
+                new MutableSummaryPointTree() {
+                    final int[] ords = new int[numPoints];
+                    int[] temp;
+
+                    {
+                        for (int i = 0; i < numPoints; ++i) {
+                            ords[i] = i;
+                        }
+                    }
+
+                    @Override
+                    public long size() {
+                        return numPoints;
+                    }
+
+                    @Override
+                    public void visitDocValues(PointValues.IntersectVisitor visitor) throws IOException {
+                        final BytesRef scratch = new BytesRef();
+                        final byte[] packedValue = new byte[packedBytesLength];
+
+                        final BytesRef summaryScratch = new BytesRef();
+                        final byte[] packedSummaryValue = new byte[packedSummaryLength];
+
+                        for (int i = 0; i < numPoints; i++) {
+                            getValue(i, scratch);
+                            assert scratch.length == packedValue.length;
+                            System.arraycopy(scratch.bytes, scratch.offset, packedValue, 0, packedBytesLength);
+                            //visitor.visit(getDocID(i), packedValue);
+
+                            final int offset =  packedSummaryLength * ords[i];
+                            summaryBytesReader.fillSlice(summaryScratch, offset, packedSummaryLength);
+                            System.arraycopy(summaryScratch.bytes, summaryScratch.offset, packedSummaryValue, 0,
+                                    packedSummaryLength);
+                            visitor.visit(getDocID(i), packedValue, packedSummaryValue);
+                        }
+                    }
+
+                    @Override
+                    public void swap(int i, int j) {
+                        int tmp = ords[i];
+                        ords[i] = ords[j];
+                        ords[j] = tmp;
+                    }
+
+                    @Override
+                    public int getDocID(int i) {
+                        return docIDs[ords[i]];
+                    }
+
+                    @Override
+                    public void getValue(int i, BytesRef packedValue) {
+                        final long offset = (long) packedBytesLength * ords[i];
+                        bytesReader.fillSlice(packedValue, offset, packedBytesLength);
+                    }
+
+                    @Override
+                    public byte getByteAt(int i, int k) {
+                        final long offset = (long) packedBytesLength * ords[i] + k;
+                        return bytesReader.getByte(offset);
+                    }
+
+                    @Override
+                    public void save(int i, int j) {
+                        if (temp == null) {
+                            temp = new int[ords.length];
+                        }
+                        temp[j] = ords[i];
+                    }
+
+                    @Override
+                    public void restore(int i, int j) {
+                        if (temp != null) {
+                            System.arraycopy(temp, i, ords, i, j - i);
+                        }
+                    }
+                };
+
+        final PointValues.PointTree values;
+        if (sortMap == null) {
+            values = points;
+        } else {
+            values = new MutableSortingPointValues(points, sortMap);
+        }
+        PointsReader reader =
+                new PointsReader() {
+                    @Override
+                    public PointValues getValues(String fieldName) {
+                        if (fieldName.equals(fieldInfo.name) == false) {
+                            throw new IllegalArgumentException("fieldName must be the same");
+                        }
+                        return new PointValues() {
+                            @Override
+                            public PointTree getPointTree() throws IOException {
+                                return values;
+                            }
+
+                            @Override
+                            public byte[] getMinPackedValue() throws IOException {
+                                throw new UnsupportedOperationException();
+                            }
+
+                            @Override
+                            public byte[] getMaxPackedValue() throws IOException {
+                                throw new UnsupportedOperationException();
+                            }
+
+                            @Override
+                            public int getNumDimensions() throws IOException {
+                                throw new UnsupportedOperationException();
+                            }
+
+                            @Override
+                            public int getNumIndexDimensions() throws IOException {
+                                throw new UnsupportedOperationException();
+                            }
+
+                            @Override
+                            public int getBytesPerDimension() throws IOException {
+                                throw new UnsupportedOperationException();
+                            }
+
+                            @Override
+                            public long size() {
+                                throw new UnsupportedOperationException();
+                            }
+
+                            @Override
+                            public int getDocCount() {
+                                throw new UnsupportedOperationException();
+                            }
+                        };
+                    }
+
+                    @Override
+                    public void checkIntegrity() {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+        writer.writeField(fieldInfo, reader);
+    }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -51,8 +51,8 @@ public abstract class PointRangeQuery extends Query {
   final String field;
   final int numDims;
   final int bytesPerDim;
-  final byte[] lowerPoint;
-  final byte[] upperPoint;
+  protected final byte[] lowerPoint;
+  protected final byte[] upperPoint;
 
   /**
    * Expert: create a multidimensional range query for point values.

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -45,7 +45,7 @@ public class BKDReader extends PointValues {
 
   final IndexInput packedIndex;
   // if true, the tree is a legacy balanced tree
-  private final boolean isTreeBalanced;
+  final boolean isTreeBalanced;
 
   /**
    * Caller must pre-seek the provided {@link IndexInput} to the index location that {@link
@@ -169,8 +169,8 @@ public class BKDReader extends PointValues {
         isTreeBalanced);
   }
 
-  private static class BKDPointTree implements PointTree {
-    private int nodeID;
+  static class BKDPointTree implements PointTree {
+    int nodeID;
     // during clone, the node root can be different to 1
     private final int nodeRoot;
     // level is 1-based so that we can do level-1 w/o checking each time:
@@ -200,17 +200,17 @@ public class BKDReader extends PointValues {
     // holds the previous value of the split dimension
     private final byte[][] splitDimValueStack;
     // tree parameters
-    private final BKDConfig config;
+    final BKDConfig config;
     // number of leaves
-    private final int leafNodeOffset;
+    final int leafNodeOffset;
     // version of the index
     private final int version;
     // total number of points
     final long pointCount;
     // last node might not be fully populated
-    private final int lastLeafNodePointCount;
+    final int lastLeafNodePointCount;
     // right most leaf node ID
-    private final int rightMostLeafNode;
+    final int rightMostLeafNode;
     // helper objects for reading doc values
     private final byte[] scratchDataPackedValue,
         scratchMinIndexPackedValue,
@@ -219,9 +219,9 @@ public class BKDReader extends PointValues {
     private final BKDReaderDocIDSetIterator scratchIterator;
     private final DocIdsWriter docIdsWriter;
     // if true the tree is balanced, otherwise unbalanced
-    private final boolean isTreeBalanced;
+    final boolean isTreeBalanced;
 
-    private BKDPointTree(
+    BKDPointTree(
         IndexInput innerNodes,
         IndexInput leafNodes,
         BKDConfig config,
@@ -365,7 +365,7 @@ public class BKDReader extends PointValues {
       return true;
     }
 
-    private void resetNodeDataPosition() throws IOException {
+    void resetNodeDataPosition() throws IOException {
       // move position of the inner nodes index to visit the first child
       assert readNodeDataPositions[level] <= innerNodes.getFilePointer();
       innerNodes.seek(readNodeDataPositions[level]);
@@ -395,7 +395,7 @@ public class BKDReader extends PointValues {
           splitValuesStack[level], splitDimPos, maxPackedValue, splitDimPos, config.bytesPerDim);
     }
 
-    private void pushLeft() throws IOException {
+    void pushLeft() throws IOException {
       nodeID *= 2;
       level++;
       readNodeData(true);
@@ -477,7 +477,7 @@ public class BKDReader extends PointValues {
       return (nodeID & 1) == 0;
     }
 
-    private boolean isLeafNode() {
+     boolean isLeafNode() {
       return nodeID >= leafNodeOffset;
     }
 
@@ -653,7 +653,7 @@ public class BKDReader extends PointValues {
       }
     }
 
-    private void readNodeData(boolean isLeft) throws IOException {
+    void readNodeData(boolean isLeft) throws IOException {
       leafBlockFPStack[level] = leafBlockFPStack[level - 1];
       if (isLeft == false) {
         // read leaf block FP delta

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDSummaryWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDSummaryWriter.java
@@ -1,0 +1,271 @@
+package org.apache.lucene.util.bkd;
+
+import org.apache.lucene.codecs.MutablePointTree;
+import org.apache.lucene.codecs.MutableSummaryPointTree;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IndexOutput;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BKDSummaryWriter extends BKDWriter {
+
+    public BKDSummaryWriter(int maxDoc, Directory tempDir, String tempFileNamePrefix, BKDConfig config,
+                            double maxMBSortInHeap, long totalPointCount) {
+        super(maxDoc, tempDir, tempFileNamePrefix, config, maxMBSortInHeap, totalPointCount);
+    }
+
+    public Runnable writeField(
+            IndexOutput metaOut,
+            IndexOutput indexOut,
+            IndexOutput dataOut,
+            IndexOutput summaryIndexOut,
+            IndexOutput summaryDataOut,
+            String fieldName,
+            MutableSummaryPointTree reader,
+            SummaryMergeFunction<?> mergeSummary)
+            throws IOException {
+        assert config.numDims == 1;
+        return writeField1Dim(metaOut, indexOut, dataOut, summaryIndexOut, summaryDataOut, fieldName, reader, mergeSummary);
+    }
+
+    Runnable writeField1Dim(
+            IndexOutput metaOut,
+            IndexOutput indexOut,
+            IndexOutput dataOut,
+            IndexOutput summaryIndexOut,
+            IndexOutput summaryDataOut,
+            String fieldName,
+            MutablePointTree reader,
+            SummaryMergeFunction<?> mergeSummary)
+            throws IOException {
+        MutablePointTreeReaderUtils.sort(config, getMaxDoc(), reader, 0, Math.toIntExact(reader.size()));
+
+        final OneDimensionBKDSummaryWriter oneDimWriter =
+                new OneDimensionBKDSummaryWriter(metaOut, indexOut, dataOut, summaryIndexOut, summaryDataOut,
+                        mergeSummary);
+
+        reader.visitDocValues(
+                new PointValues.IntersectVisitor() {
+
+                    @Override
+                    public void visit(int docID, byte[] packedValue) throws IOException {
+                        oneDimWriter.add(packedValue, docID);
+                    }
+
+                    @Override
+                    public void visit(int docID, byte[] packedValue, byte[] summaryData) throws IOException {
+                        oneDimWriter.add(packedValue, summaryData, docID);
+                    }
+
+                    @Override
+                    public void visit(int docID) {
+                        throw new IllegalStateException();
+                    }
+
+                    @Override
+                    public PointValues.Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+                        return PointValues.Relation.CELL_CROSSES_QUERY;
+                    }
+                });
+
+        return oneDimWriter.finish();
+    }
+
+    class OneDimensionBKDSummaryWriter extends OneDimensionBKDWriter {
+
+        IndexOutput summaryDataOut;
+        IndexOutput summaryIndexOut;
+
+        long summaryIndexFP, summaryDataFP;
+
+        final List<Long> summaryLeafBlockFPs = new ArrayList<>();
+        final List<byte[]> leafBlockSummary = new ArrayList<>();
+        byte[] summaryLeafNodeValue;
+        SummaryMergeFunction<?> mergeFunction;
+        int summaryBytesLength = 0;
+        long packedDataLength = 0;
+        OneDimensionBKDSummaryWriter(IndexOutput metaOut, IndexOutput indexOut, IndexOutput dataOut, IndexOutput summaryIndexOut,
+                              IndexOutput summaryDataOut, SummaryMergeFunction<?> mergeFunction) {
+            super(metaOut, indexOut, dataOut);
+            this.summaryDataOut = summaryDataOut;
+            this.summaryIndexOut = summaryIndexOut;
+            this.summaryBytesLength = mergeFunction.getSummarySize();
+            this.summaryIndexFP = summaryIndexOut.getFilePointer();
+            this.summaryDataFP = summaryDataOut.getFilePointer();
+
+            this.mergeFunction = mergeFunction;
+            this.summaryLeafNodeValue = new byte[config.maxPointsInLeafNode * summaryBytesLength];
+            packedDataLength = 0;
+        }
+
+        void add(byte[] packedValue, byte[] summaryValue, int docID) throws IOException {
+            int leafCount = getLeafCount();
+            add(packedValue, docID);
+            addSummary( leafCount + 1 , summaryValue);
+        }
+
+        @Override
+        public Runnable finish() throws IOException {
+            int leftOverPoints = getLeafCount();
+            Runnable bkdWriterFinishResult = super.finish();
+            if (leftOverPoints > 0) {
+                writeLeafBlockSummaryData(leftOverPoints);
+            }
+
+            if (valueCount == 0) {
+                return null;
+            }
+
+            pointCount = valueCount;
+
+            BKDTreeSummaryLeafNodes summaryLeafNodes = new BKDTreeSummaryLeafNodes() {
+                @Override
+                public long getSummaryLeafFP(int index) {
+                    return summaryLeafBlockFPs.get(index);
+                }
+
+                @Override
+                public byte[] getLeafSummary(int index) {
+                    return leafBlockSummary.get(index);
+                }
+            };
+            int numLeaves = summaryLeafBlockFPs.size();
+            return (() -> {
+                try {
+                    bkdWriterFinishResult.run();
+                    writeSummaryIndex(metaOut, summaryIndexOut, numLeaves, summaryLeafNodes, summaryBytesLength,
+                            summaryIndexFP);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        }
+
+
+        private void addSummary(int leafCount, byte[] summaryValue) throws IOException {
+            System.arraycopy(
+                    summaryValue,
+                    0,
+                    summaryLeafNodeValue,
+                    (leafCount - 1) * summaryBytesLength,
+                    summaryBytesLength);
+            if (leafCount == config.maxPointsInLeafNode) {
+                writeLeafBlockSummaryData(leafCount);
+            }
+        }
+
+        void writeLeafBlockSummaryData(int leafCount) throws IOException {
+            if (summaryLeafNodeValue.length == 0) {
+                return;
+            }
+            summaryLeafBlockFPs.add(summaryDataOut.getFilePointer());
+            // summaryLeafOut.writeBytes(summaryLeafNodeValue, 0, summaryBytesLength*config.maxPointsInLeafNode);
+            byte[] cumulativeLeafSummary = new byte[summaryBytesLength];
+            byte[] currentValue = new byte[summaryBytesLength];
+
+            System.arraycopy(summaryLeafNodeValue, 0, cumulativeLeafSummary,0, summaryBytesLength);
+            // TODO compress the bytes before writing the summary data
+            summaryDataOut.writeBytes(summaryLeafNodeValue, summaryBytesLength*leafCount);
+            // summaryDataOut.writeInt(leafCount);
+            for (int i = 1; i < leafCount; i++) {
+                System.arraycopy(summaryLeafNodeValue, i*summaryBytesLength, currentValue,0, summaryBytesLength);
+                mergeFunction.merge(cumulativeLeafSummary, currentValue, cumulativeLeafSummary);
+                //summaryDataOut.writeBytes(currentValue, summaryBytesLength);
+            }
+            packedDataLength += summaryBytesLength*leafCount;
+            leafBlockSummary.add(cumulativeLeafSummary);
+        }
+
+        private void writeSummary(IndexOutput metaOut, IndexOutput summaryIndexOut, int summaryBytesLength,
+                                  byte[] packedSummary, long summaryIndexFP)
+                throws IOException {
+            metaOut.writeVInt(summaryBytesLength);
+            metaOut.writeLong(packedSummary.length);
+            metaOut.writeLong(packedDataLength);
+
+            metaOut.writeLong(summaryIndexFP);
+            metaOut.writeLong(summaryDataFP);
+
+            summaryIndexOut.writeBytes(packedSummary, 0, packedSummary.length);
+        }
+
+        private void writeSummaryIndex(
+                IndexOutput metaOut,
+                IndexOutput summaryIndexOut,
+                int numLeaves,
+                BKDTreeSummaryLeafNodes summaryLeafNodes,
+                int summaryBytesLength,
+                long summaryIndexFP)
+                throws IOException {
+            byte[] packedSummary = packSummary(numLeaves, summaryLeafNodes, summaryBytesLength);
+            writeSummary(metaOut, summaryIndexOut, summaryBytesLength, packedSummary, summaryIndexFP);
+        }
+
+        private byte[] packSummary(int numLeafNodes, BKDTreeSummaryLeafNodes summaryLeafNodes, int summaryBytesLength)
+                throws IOException {
+            ByteBuffersDataOutput writeBuffer = ByteBuffersDataOutput.newResettableInstance();
+            List<byte[]> blocks = new ArrayList<>();
+            int totalSize = recursePackSummary(numLeafNodes, 0, summaryLeafNodes, writeBuffer,
+                    summaryBytesLength, new byte[summaryBytesLength], blocks);
+
+            // Compact the byte[] blocks into single byte index:
+            byte[] summary = new byte[totalSize];
+            int upto = 0;
+            for (byte[] block : blocks) {
+                System.arraycopy(block, 0, summary, upto, block.length);
+                upto += block.length;
+            }
+            assert upto == totalSize;
+            return summary;
+        }
+
+        private int recursePackSummary(
+                int numLeaves,
+                int leavesOffset,
+                BKDTreeSummaryLeafNodes summaryLeafNodes,
+                ByteBuffersDataOutput writeBuffer,
+                int summaryBytesLength,
+                byte[] nodeSummary, List<byte[]> blocks) throws IOException {
+
+            if (numLeaves == 1) {
+                System.arraycopy(summaryLeafNodes.getLeafSummary(leavesOffset), 0, nodeSummary, 0, summaryBytesLength);
+                writeBuffer.writeBytes(nodeSummary);
+                //writeBuffer.writeLong(summaryLeafNodes.getSummaryLeafFP(leavesOffset));
+                return appendBlock(writeBuffer, blocks);
+            } else {
+                int numLeftLeafNodes = getNumLeftLeafNodes(numLeaves);
+                byte[] leftSummary = new byte[summaryBytesLength];
+                int leftBytes = recursePackSummary(numLeftLeafNodes, leavesOffset, summaryLeafNodes, writeBuffer,
+                        summaryBytesLength, leftSummary, blocks);
+                byte[] rightSummary = new byte[summaryBytesLength];
+                int rightBytes = recursePackSummary(numLeaves - numLeftLeafNodes,
+                        leavesOffset + numLeftLeafNodes, summaryLeafNodes, writeBuffer, summaryBytesLength, rightSummary, blocks);
+                mergeFunction.merge(leftSummary, rightSummary, nodeSummary);
+                // System.arraycopy(leftSummary, 0, nodeSummary, 0, summaryBytesLength);
+                writeBuffer.writeBytes(nodeSummary);
+                return leftBytes + rightBytes + appendBlock(writeBuffer, blocks);
+            }
+        }
+    }
+    private interface BKDTreeSummaryLeafNodes {
+        long getSummaryLeafFP(int index);
+        byte[] getLeafSummary(int index);
+
+    }
+
+    public interface SummaryMergeFunction<T> {
+        int getSummarySize(); // in bytes
+
+        /**
+         * Merge a and b into c
+         */
+        void merge(byte[] a, byte[] b, byte[] c);
+        T unpackBytes(byte[] val);
+        void packBytes(T val, byte[] res);
+    }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWithSummaryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWithSummaryReader.java
@@ -1,0 +1,172 @@
+package org.apache.lucene.util.bkd;
+
+import org.apache.lucene.store.IndexInput;
+
+import java.io.IOException;
+
+public class BKDWithSummaryReader extends BKDReader {
+
+    IndexInput summaryIndexIn;
+    IndexInput summaryDataIn;
+    IndexInput packedSummary, packedSummaryData;
+
+    int summaryBytesLength;
+    long packedSummaryLength, packedSummaryDataLength;
+    long summaryIndexFP, summaryDataFP;
+    /**
+     * Caller must pre-seek the provided {@link IndexInput} to the index location that {@link
+     * BKDWriter#finish} returned. BKD tree is always stored off-heap.
+     *
+     * @param metaIn
+     * @param indexIn
+     * @param dataIn
+     */
+    public BKDWithSummaryReader(IndexInput metaIn, IndexInput indexIn, IndexInput dataIn,
+                                IndexInput summaryIndexIn, IndexInput summaryDataIn) throws IOException {
+        super(metaIn, indexIn, dataIn);
+        this.summaryIndexIn = summaryIndexIn;
+        this.summaryDataIn = summaryDataIn;
+        this.summaryBytesLength = metaIn.readVInt();
+        this.packedSummaryLength = metaIn.readLong();
+        this.packedSummaryDataLength = metaIn.readLong();
+
+        this.summaryIndexFP = metaIn.readLong();
+        this.summaryDataFP = metaIn.readLong();
+        summaryIndexIn.seek(summaryIndexFP);
+        summaryDataIn.seek(summaryDataFP); // TODO fetch index from metadata
+        this.packedSummary = summaryIndexIn.slice("packedSummaryIndex", summaryIndexFP,
+                packedSummaryLength);
+        this.packedSummaryData = summaryDataIn.slice("packedSummaryData", summaryDataFP,
+                packedSummaryDataLength);
+
+    }
+
+    public class BKDSummaryTree extends BKDPointTree {
+        IndexInput summaryNodes;
+        IndexInput summaryData;
+
+        public BKDSummaryTree(IndexInput innerNodes, IndexInput leafNodes, IndexInput summaryNodes,
+                              IndexInput summaryDataIn, BKDConfig config, int numLeaves, int version,
+                       long pointCount, byte[] minPackedValue, byte[] maxPackedValue, boolean isTreeBalanced)
+                throws IOException {
+            super(innerNodes, leafNodes, config, numLeaves, version, pointCount, minPackedValue, maxPackedValue,
+                    isTreeBalanced);
+            this.summaryNodes = summaryNodes;
+            this.summaryData = summaryDataIn;
+        }
+
+        public long visitSummary(IntersectVisitor visitor, long summaryBytesOffset) throws IOException {
+            Relation r = visitor.compare(this.getMinPackedValue(), this.getMaxPackedValue());
+            switch (r) {
+                case CELL_OUTSIDE_QUERY:
+                    // This cell is fully outside the query shape: return 0 as the count of its nodes
+                    return summaryBytesOffset + summarySizeUnderCurrentNode();
+                case CELL_INSIDE_QUERY:
+                    // This cell is fully inside the query shape: return the size of the entire node as the
+                    // count
+                    long summarySizeUnderCurrentNode = summarySizeUnderCurrentNode();
+                    summaryNodes.seek(Math.max(0, summaryBytesOffset + summarySizeUnderCurrentNode - summaryBytesLength));
+                    byte [] summaryBytes = new byte[summaryBytesLength];
+                    summaryNodes.readBytes(summaryBytes, 0, summaryBytesLength);
+                    visitor.visit(summaryBytes, -1, -1);
+                    return summaryBytesOffset + summarySizeUnderCurrentNode;
+                case CELL_CROSSES_QUERY:
+                    /*
+                    The cell crosses the shape boundary, or the cell fully contains the query, so we fall
+                    through and do full counting.
+                    */
+                    if (!this.moveToChild()) {
+                        long offset = (long) currNodeLeafOrderOffset() *config.maxPointsInLeafNode*summaryBytesLength;
+                        final int[] i = {0};
+                        final byte[][] scratch = {new byte[summaryBytesLength]};
+
+                        this.visitDocValues(new IntersectVisitor() {
+                            @Override
+                            public void visit(int docID) throws IOException {
+
+                            }
+
+                            @Override
+                            public void visit(int docID, byte[] packedValue) throws IOException {
+                                summaryData.seek(offset + (long) i[0] *summaryBytesLength);
+                                summaryData.readBytes(scratch[0], 0, summaryBytesLength);
+                                visitor.visit(i[0], packedValue, scratch[0]);
+                                i[0]++;
+                            }
+
+                            @Override
+                            public Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+                                return visitor.compare(minPackedValue, maxPackedValue);
+                            }
+                        });
+                        return summaryBytesOffset + summaryBytesLength;
+                    } else {
+                        // in-place traversal
+                        long leftBytesOffset = visitSummary(visitor, summaryBytesOffset);
+                        this.moveToSibling();
+                        long rightBytesOffset = visitSummary(visitor, leftBytesOffset);
+                        this.moveToParent();
+                        return rightBytesOffset + summaryBytesLength;
+                    }
+
+                default:
+                    throw new IllegalArgumentException("Unreachable code");
+            }
+        }
+
+        private int currNodeLeafOrderOffset() {
+            // leaves = 8
+            int totalNodes = numLeaves*2-1; //numNodes = leaves*2 -1 = 15
+
+            int firstOrderedLeaf = totalNodes - leafNodeOffset + 1; // startingLeaf = numNodes - leaves + 1 = 8
+            int msb = 31 - Integer.numberOfLeadingZeros(totalNodes);
+            int lastLevelLeaves = totalNodes - (1<<msb) + 1;
+            // lastLevelLeaves = numNodes - 2^msb(leaves) + 1 = 15 - 2^4 + 1 = 0
+            return (nodeID - firstOrderedLeaf + lastLevelLeaves)%numLeaves;
+            // ((node - startingLeaf)+lastLevelLeaves)%leaves + 1
+        }
+        private long summarySizeUnderCurrentNode() {
+            int leftMostLeafNode = nodeID;
+            int fullLevelUnderCurrentNode = 0;
+            while (leftMostLeafNode < leafNodeOffset) {
+                leftMostLeafNode = leftMostLeafNode * 2;
+                fullLevelUnderCurrentNode++;
+            }
+            int treeLeftMostNode = 1;
+            while (treeLeftMostNode < leafNodeOffset) {
+                treeLeftMostNode = treeLeftMostNode * 2;
+            }
+            int rightMostLeafNode = nodeID;
+            while (rightMostLeafNode < leafNodeOffset) {
+                rightMostLeafNode = rightMostLeafNode * 2 + 1;
+            }
+
+            int lastFullLevel = 31 - Integer.numberOfLeadingZeros(numLeaves);
+            // how many leaf nodes are in the full level
+            int leavesFullLevel = 1 << lastFullLevel;
+            // leaf nodes that do not fit in the full level
+            int unbalancedLeafNodes = numLeaves - leavesFullLevel;
+            if (rightMostLeafNode >= leftMostLeafNode) {
+                return ((1L<<(fullLevelUnderCurrentNode+1)) -1)*summaryBytesLength;
+            }
+            return ((long) unbalancedLeafNodes*2 - leftMostLeafNode + treeLeftMostNode + (1L<<fullLevelUnderCurrentNode) -1)
+                    *summaryBytesLength;
+        }
+    }
+
+    @Override
+    public BKDSummaryTree getPointTree() throws IOException {
+        return new BKDSummaryTree(
+                packedIndex.clone(),
+                this.in.clone(),
+                this.packedSummary.clone(),
+                this.packedSummaryData.clone(),
+                config,
+                numLeaves,
+                version,
+                pointCount,
+                minPackedValue,
+                maxPackedValue,
+                isTreeBalanced);
+    }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
@@ -130,6 +130,9 @@ public class BKDWriter implements Closeable {
   private final long totalPointCount;
 
   private final int maxDoc;
+  int getMaxDoc() {
+    return maxDoc;
+  }
   private final DocIdsWriter docIdsWriter;
 
   public BKDWriter(
@@ -668,7 +671,7 @@ public class BKDWriter implements Closeable {
     return oneDimWriter.finish();
   }
 
-  private class OneDimensionBKDWriter {
+  protected class OneDimensionBKDWriter {
 
     final IndexOutput metaOut, indexOut, dataOut;
     final long dataStartFP;
@@ -676,8 +679,11 @@ public class BKDWriter implements Closeable {
     final List<byte[]> leafBlockStartValues = new ArrayList<>();
     final byte[] leafValues = new byte[config.maxPointsInLeafNode * config.packedBytesLength];
     final int[] leafDocs = new int[config.maxPointsInLeafNode];
-    private long valueCount;
+    protected long valueCount;
     private int leafCount;
+    int getLeafCount() {
+      return leafCount;
+    }
     private int leafCardinality;
 
     OneDimensionBKDWriter(IndexOutput metaOut, IndexOutput indexOut, IndexOutput dataOut) {
@@ -788,6 +794,7 @@ public class BKDWriter implements Closeable {
               return leafBlockFPs.size();
             }
           };
+
       return () -> {
         try {
           writeIndex(metaOut, indexOut, config.maxPointsInLeafNode, leafNodes, dataStartFP);
@@ -855,7 +862,7 @@ public class BKDWriter implements Closeable {
     }
   }
 
-  private int getNumLeftLeafNodes(int numLeaves) {
+  protected int getNumLeftLeafNodes(int numLeaves) {
     assert numLeaves > 1 : "getNumLeftLeaveNodes() called with " + numLeaves;
     // return the level that can be filled with this number of leaves
     int lastFullLevel = 31 - Integer.numberOfLeadingZeros(numLeaves);
@@ -1071,7 +1078,7 @@ public class BKDWriter implements Closeable {
   }
 
   /** Appends the current contents of writeBuffer as another block on the growing in-memory file */
-  private int appendBlock(ByteBuffersDataOutput writeBuffer, List<byte[]> blocks) {
+  protected int appendBlock(ByteBuffersDataOutput writeBuffer, List<byte[]> blocks) {
     byte[] block = writeBuffer.toArrayCopy();
     blocks.add(block);
     writeBuffer.reset();
@@ -1244,7 +1251,7 @@ public class BKDWriter implements Closeable {
     }
   }
 
-  private void writeIndex(
+  protected void writeIndex(
       IndexOutput metaOut,
       IndexOutput indexOut,
       int countPerLeaf,


### PR DESCRIPTION
### Description
Support faster range queries on `timestamp` field by using precomputed (while indexing) aggregated stats (such as `min, max, count, sum, avg` or any other [decomposable aggregation function](https://en.wikipedia.org/wiki/Aggregate_function#Decomposable_aggregate_functions)) on `measurement` associated with a `timeseries` point. 

#### Changes

#### Usage

**Index**

```java
Document doc = new Document();
doc.add(new TSIntPoint("tsid1", "cpu", timestamp, measurement));
```

**Search**

```java
LeafReader leafReader;
PointValues points = leafReader.getPointValues("tsid1");
TSPointQuery tsPointQuery = new TSPointQuery("tsid1", lowerBoundTimestamp, upperBoundTimestamp);
byte[] res = tsPointQuery.getSummary((BKDWithSummaryReader.BKDSummaryTree) points.getPointTree(), mergeFunction);
```

**Stats merge function definiton**

*Sum*
```java
new BKDSummaryWriter.SummaryMergeFunction<Integer>() {

      @Override
      public int getSummarySize() {
        return Integer.BYTES;
      }

      @Override
      public void merge(byte[] a, byte[] b, byte[] c) {
        packBytes(unpackBytes(a) + unpackBytes(b), c);
      }

      @Override
      public Integer unpackBytes(byte[] val) {
        return NumericUtils.sortableBytesToInt(val, 0);
      }

      @Override
      public void packBytes(Integer val, byte[] res) {
        NumericUtils.intToSortableBytes(val, res, 0);
      }
    };
```
*Long max fn*
```java
  static class LongMaxFunction implements BKDSummaryWriter.SummaryMergeFunction<Long> {

    @Override
    public int getSummarySize() {
      return Long.BYTES;
    }

    @Override
    public void merge(byte[] a, byte[] b, byte[] res) {
      if (unpackBytes(a) < unpackBytes(b)) {
        System.arraycopy(b, 0, res, 0, getSummarySize());
      } else {
        System.arraycopy(a, 0, res, 0, getSummarySize());
      }
    }

    @Override
    public Long unpackBytes(byte[] val) {
      return NumericUtils.sortableBytesToLong(val, 0);
    }

    @Override
    public void packBytes(Long val, byte[] res) {
      NumericUtils.longToSortableBytes(val, res, 0);
    }
  }
```
#### Comparison with DocValues
Below is the comparison of running unit test for [DocValue](https://github.com/rishabhmaurya/lucene/pull/1/commits/157215cd2c4787787748625e10b58001583c6e6e#diff-87c31ac3b1cd1ef45b15c84d9cf1c5bab03feb94f199256f859f14ed4747abd2R129) approach vs [TSPoint](https://github.com/rishabhmaurya/lucene/pull/1/commits/157215cd2c4787787748625e10b58001583c6e6e#diff-87c31ac3b1cd1ef45b15c84d9cf1c5bab03feb94f199256f859f14ed4747abd2R52) approach - 

This test ingests `10000000` docs against a given TSID and performs a range query on timestamp 100 times against the same TSID. Merge function used is `sum`.

| DocValues approach     |  TSPoint approach|
| ----------------------- | ------------------ |
|Indexing took: 42948 ms  | Indexing took: 32985       |
|Matching docs count:1304624 \| Segments:3 \| DiskAccess: 1304624 | Matching docs count:8784032 \| Segments:10 \| DiskAccess: 302       |
|Search took: 12382 ms     | Search took: 50ms |

This is not apple to apple comparison since number of segments are 3 in DocValues approach whereas its 10 in TSPoint approach. 

#### Limitation of this feature
* Doc deletion currently not supported. We need to evaluate how important is it and possibly find a way to support it in future.
* Only limited stats function would be supported which can be computed accurately by aggregating 2 points. E.g. min, max, sum, avg, count. 
* Filter query would only be supported on TimeSeries ID(TSID). TSID will be computed using hashing the dimension fields.
* Range query will only be supported on `timestamp`. 

#### TODOs
* Implementation for multiple TSIDs. For now we need to create a new field with the name same as TSID for a timeseries.
* Segment merge for BKD with summaries. Currently, the UTs disables merge and perform search across multiple segments and cumulate the results.
* Pluggable merge function to merge 2 `TSPoint`. Currently its hardcoded in `FieldInfo.java` which isn't the right place to define them.
* Measurement compression in BKD. I'm thinking of using delta encoding to store measurement values and summaries while packing the summaries associated with nodes of the tree. 
* Persist first and last docID in internal nodes of BKD with summaries in an efficient way. This will be useful to use precomputed summaries and skip over batches of documents when iterating using DocIDSetIterator. Its a blocker for integration with OpenSearch aggregation framework.
* Integrate with OpenSearch aggregation framework.
* Benchmark against real timeseries dataset. 
* * compare against SortedDocValues approach.
* * compare against other timeseries databases.
* Evaluate support of deletion of document/timeseries/batch of documents (matching a timestamp range).

#### New interfaces

#### Compression of values and timestamp

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
