### PR TITLE
Changes to prune numeric comparator

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/LeafFieldComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LeafFieldComparator.java
@@ -96,6 +96,10 @@ public interface LeafFieldComparator {
    */
   void setScorer(Scorable scorer) throws IOException;
 
+  default void setScorer(Scorable scorer, int numHits) throws IOException {
+    this.setScorer(scorer);
+  }
+
   /**
    * Returns a competitive iterator
    *

--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
@@ -27,6 +27,7 @@ import org.apache.lucene.index.ReaderUtil;
 import org.apache.lucene.search.FieldValueHitQueue.Entry;
 import org.apache.lucene.search.MaxScoreAccumulator.DocAndScore;
 import org.apache.lucene.search.TotalHits.Relation;
+import org.apache.lucene.search.comparators.NumericComparator;
 
 /**
  * A {@link Collector} that sorts by {@link SortField} using {@link FieldComparator}s.
@@ -133,7 +134,11 @@ public abstract class TopFieldCollector extends TopDocsCollector<Entry> {
     @Override
     public void setScorer(Scorable scorer) throws IOException {
       this.scorer = scorer;
-      comparator.setScorer(scorer);
+      if (comparator instanceof NumericComparator) {
+        comparator.setScorer(scorer, numHits);
+      } else {
+        comparator.setScorer(scorer);
+      }
       if (minScoreAcc == null) {
         updateMinCompetitiveScore(scorer);
       } else {


### PR DESCRIPTION
### Description
TopFieldCollector, where the number of hits to collect is known before hand, can we make use of it to only collect most competitive hits collected by NumericCollector? Competitive iterator in NumericCollector will make use of BKD (when defined criteria is met) and will traverse the points in ascending order and if the query sort order is ascending too it works pretty well, as most competitive hits would be collected first and rest of them can be discarded fast. When query sort order is descending, it can cause priority queue churning and read amplification because of doc values retrieval because of collection of non-competitive in the beginning, as most competitive docs are towards the end of BKD. 
If we know how many hits we need to collect, can we directly move to the right node of the tree and start collecting competitive docs thereafter? 
This could be helpful for the cases where segment is big and difference between numHits << docs in segment (matching query) as it could prune large set of non competitive docs. 

BKD and numeric comparator code is new to me and I might be missing few critical cases, but here is my best effort to implement something closest.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
